### PR TITLE
Credentials should remain optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ target/
 
 # Ignore [ce]tags files
 tags
+
+# Idea
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -42,7 +42,16 @@ You may also *optionally* specify a repository as the second argument. **This is
 
 This resolver will give you access to packages published on *any* repository within the organization. If the token provided in the authentication information only has access to public repositories, then packages published on private repositories will report "not found". If the token has access to private repositories as well as public, then all packages will be visible.
 
-You will need to ensure that `githubTokenSource` is set to *your* details (i.e. the authentication information for the individual who ran `sbt`). The `TokenSource` ADT has the following possibilities:
+### Authentication
+
+You will need to ensure that `githubTokenSource` is set to *your* details (i.e. the authentication information for the individual who ran `sbt`). If you do
+not establish a token source then you will be unable to authenticate, and you will receive the following message when you attempt to publish:
+
+```
+[error] Unable to find credentials for [GitHub Package Registry @ maven.pkg.github.com].
+```
+
+The `TokenSource` ADT has the following possibilities:
 
 ```scala
 sealed trait TokenSource extends Product with Serializable {

--- a/src/main/scala/sbtghpackages/GitHubPackagesKeys.scala
+++ b/src/main/scala/sbtghpackages/GitHubPackagesKeys.scala
@@ -24,7 +24,7 @@ trait GitHubPackagesKeys {
 
   val githubTokenSource = settingKey[TokenSource]("Where to get the API token used in publication (defaults to github.token in the git config)")
 
-  val githubSuppressPublicationWarning = settingKey[Boolean]("Whether or not to suppress the publication warning (default: false, meaning the warning will be printed)")
+  val githubSuppressPublicationWarning = settingKey[Boolean]("Whether or not to suppress a publication warning (default: false, meaning the warning will be printed)")
 
   val githubPublishTo = taskKey[Option[Resolver]]("publishTo setting for deploying artifacts to GitHub packages")
 }

--- a/src/main/scala/sbtghpackages/GitHubPackagesPlugin.scala
+++ b/src/main/scala/sbtghpackages/GitHubPackagesPlugin.scala
@@ -43,14 +43,14 @@ object GitHubPackagesPlugin extends AutoPlugin {
   val authenticationSettings = Seq(
     githubTokenSource := TokenSource.Environment("GITHUB_TOKEN"),
 
-    credentials += {
+    credentials ++= {
       val src = githubTokenSource.value
       inferredGitHubCredentials("_", src) match {   // user is ignored by GitHub, so just use "_"
         case Some(creds) =>
-          creds
+          Seq(creds)
 
         case None =>
-          sys.error(s"unable to locate a valid GitHub token from $src")
+          Seq.empty
       }
     })
 


### PR DESCRIPTION
When publishing with sbt, I believe credentials are only required when the endpoint receiving its artifacts requires them. This PR re-enables this behaviour. As a consequence, the plugin may be used in situations where the user has no credentials given that they are unauthorised to publish artifacts. A valid scenario is that Continuous Delivery is authorised to publish, but no other user.

The plugin also now works in the context of an IDE where the `GITHUB_TOKEN` environment variable is not found.

Should address https://github.com/djspiewak/sbt-github-packages/issues/30, https://github.com/djspiewak/sbt-github-packages/issues/28, https://github.com/djspiewak/sbt-github-packages/issues/26, https://github.com/djspiewak/sbt-github-packages/issues/16 - but please re-check.