### PR TITLE
Add TokenSource.Property

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ sealed trait TokenSource extends Product with Serializable {
 
 object TokenSource {
   final case class Environment(variable: String) extends TokenSource
+  final case class Property(key: String) extends TokenSource
   final case class GitConfig(key: String) extends TokenSource
   final case class Or(primary: TokenSource, secondary: TokenSource) extends TokenSource
 }
@@ -79,6 +80,18 @@ This assumes you have your token stored there like this:
 [github]
   token = TOKEN_DATA
 ```
+
+To use a token from the process properties it should be specified when running sbt:
+```bash
+$ sbt -DGITHUB_TOKEN=abcdef12345cafebab 
+```
+
+or create `.sbtopts` file in the project directory with the following content:
+```
+-DGITHUB_TOKEN=abcdef12345cafeba
+```
+
+The option above is suitable for importing the project into IntelliJ IDEA.
 
 The `||` combinator allows you to configure multiple token sources which will be tried in order on first-read of the setting.
 

--- a/src/main/scala/sbtghpackages/GitHubPackagesPlugin.scala
+++ b/src/main/scala/sbtghpackages/GitHubPackagesPlugin.scala
@@ -44,13 +44,20 @@ object GitHubPackagesPlugin extends AutoPlugin {
     githubTokenSource := TokenSource.Environment("GITHUB_TOKEN") || TokenSource.Property("GITHUB_TOKEN"),
 
     credentials += {
+      val log = streams.value.log
       val src = githubTokenSource.value
       inferredGitHubCredentials("_", src) match {   // user is ignored by GitHub, so just use "_"
         case Some(creds) =>
           creds
 
         case None =>
-          sys.error(s"unable to locate a valid GitHub token from $src")
+          log.error(s"Unable to locate a valid GitHub token from $src")
+          log.error("To provide token explicitly, use `GITHUB_TOKEN=<your token> sbt` or `sbt -DGITHUB_TOKEN=<your token>`")
+          log.error(
+            "A token should have the `read:packages` permission. For more details see " +
+              "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
+          )
+          sys.error(s"Unable to locate a valid GitHub token from $src")
       }
     })
 

--- a/src/main/scala/sbtghpackages/GitHubPackagesPlugin.scala
+++ b/src/main/scala/sbtghpackages/GitHubPackagesPlugin.scala
@@ -41,7 +41,7 @@ object GitHubPackagesPlugin extends AutoPlugin {
   import autoImport._
 
   val authenticationSettings = Seq(
-    githubTokenSource := TokenSource.Environment("GITHUB_TOKEN"),
+    githubTokenSource := TokenSource.Environment("GITHUB_TOKEN") || TokenSource.Property("GITHUB_TOKEN"),
 
     credentials += {
       val src = githubTokenSource.value
@@ -121,6 +121,9 @@ object GitHubPackagesPlugin extends AutoPlugin {
 
       case TokenSource.Environment(variable) =>
         sys.env.get(variable)
+
+      case TokenSource.Property(key) =>
+        sys.props.get(key)
 
       case TokenSource.GitConfig(key) =>
         Try(s"git config $key".!!).map(_.trim).toOption

--- a/src/main/scala/sbtghpackages/TokenSource.scala
+++ b/src/main/scala/sbtghpackages/TokenSource.scala
@@ -23,6 +23,7 @@ sealed trait TokenSource extends Product with Serializable {
 
 object TokenSource {
   final case class Environment(variable: String) extends TokenSource
+  final case class Property(key: String) extends TokenSource
   final case class GitConfig(key: String) extends TokenSource
   final case class Or(primary: TokenSource, secondary: TokenSource) extends TokenSource
 }

--- a/src/sbt-test/sbtghpackages/property-token/.sbtopts
+++ b/src/sbt-test/sbtghpackages/property-token/.sbtopts
@@ -1,0 +1,1 @@
+-DGITHUB_TOKEN=test

--- a/src/sbt-test/sbtghpackages/property-token/build.sbt
+++ b/src/sbt-test/sbtghpackages/property-token/build.sbt
@@ -1,0 +1,2 @@
+name := "property-token-test"
+githubTokenSource := TokenSource.Property("GITHUB_TOKEN")

--- a/src/sbt-test/sbtghpackages/property-token/project/build.properties
+++ b/src/sbt-test/sbtghpackages/property-token/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.10

--- a/src/sbt-test/sbtghpackages/property-token/project/plugins.sbt
+++ b/src/sbt-test/sbtghpackages/property-token/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.codecommit" % "sbt-github-packages" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbtghpackages/property-token/test
+++ b/src/sbt-test/sbtghpackages/property-token/test
@@ -1,0 +1,1 @@
+> show publishTo


### PR DESCRIPTION
The aim of the PR is to solve IntelliJ IDEA importing issue. 

IDEA correctly picks up properties from `.sbtopts` file and therefore can download dependencies from the GitHub maven repository.

Partially solves #24, #26, and #42.