### PR TITLE
Remove the absolute need for github credentials, deferring errors to …

### DIFF
--- a/src/main/scala/sbtghpackages/GitHubPackagesPlugin.scala
+++ b/src/main/scala/sbtghpackages/GitHubPackagesPlugin.scala
@@ -43,14 +43,14 @@ object GitHubPackagesPlugin extends AutoPlugin {
   val authenticationSettings = Seq(
     githubTokenSource := TokenSource.Environment("GITHUB_TOKEN"),
 
-    credentials += {
+    credentials ++= {
       val src = githubTokenSource.value
       inferredGitHubCredentials("_", src) match {   // user is ignored by GitHub, so just use "_"
         case Some(creds) =>
-          creds
+          List(creds)
 
         case None =>
-          sys.error(s"unable to locate a valid GitHub token from $src")
+          Nil
       }
     })
 


### PR DESCRIPTION
This pull request is to make it so that a project does not need a github token provided in order to compile or do pretty much anything else. It defers credentials problems until they are actually needed.