### PR TITLE
Support reading GitHub token from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ You may also *optionally* specify a repository as the second argument. **This is
 
 This resolver will give you access to packages published on *any* repository within the organization. If the token provided in the authentication information only has access to public repositories, then packages published on private repositories will report "not found". If the token has access to private repositories as well as public, then all packages will be visible.
 
+#### Credentials
+
 You will need to ensure that `githubTokenSource` is set to *your* details (i.e. the authentication information for the individual who ran `sbt`). The `TokenSource` ADT has the following possibilities:
 
 ```scala
@@ -55,6 +57,7 @@ sealed trait TokenSource extends Product with Serializable {
 object TokenSource {
   final case class Environment(variable: String) extends TokenSource
   final case class GitConfig(key: String) extends TokenSource
+  final case class FromFile(file: File) extends TokenSource
   final case class Or(primary: TokenSource, secondary: TokenSource) extends TokenSource
 }
 ```
@@ -79,6 +82,14 @@ This assumes you have your token stored there like this:
 [github]
   token = TOKEN_DATA
 ```
+
+To read a token from a local file you can use something like:
+
+```sbt
+githubTokenSource := TokenSource.FromFile(Path.userHome / ".sbt" / "github.token")
+```
+
+The first line of the file will be read in and used as the GitHub token.
 
 The `||` combinator allows you to configure multiple token sources which will be tried in order on first-read of the setting.
 

--- a/src/main/scala/sbtghpackages/GitHubPackagesPlugin.scala
+++ b/src/main/scala/sbtghpackages/GitHubPackagesPlugin.scala
@@ -119,6 +119,10 @@ object GitHubPackagesPlugin extends AutoPlugin {
         resolveTokenSource(primary).orElse(
           resolveTokenSource(secondary))
 
+      case TokenSource.FromFile(file) =>
+        // Extract credentials from the first line of the file.
+        if (file.canRead) IO.readLines(file).headOption else None
+
       case TokenSource.Environment(variable) =>
         sys.env.get(variable)
 

--- a/src/main/scala/sbtghpackages/TokenSource.scala
+++ b/src/main/scala/sbtghpackages/TokenSource.scala
@@ -16,6 +16,8 @@
 
 package sbtghpackages
 
+import sbt.File
+
 sealed trait TokenSource extends Product with Serializable {
   def ||(that: TokenSource): TokenSource =
     TokenSource.Or(this, that)
@@ -24,5 +26,6 @@ sealed trait TokenSource extends Product with Serializable {
 object TokenSource {
   final case class Environment(variable: String) extends TokenSource
   final case class GitConfig(key: String) extends TokenSource
+  final case class FromFile(file: File) extends TokenSource
   final case class Or(primary: TokenSource, secondary: TokenSource) extends TokenSource
 }


### PR DESCRIPTION
Loading the GitHub token from an environment variable is great, but IntelliJ has difficulty loading sbt projects because it doesn't always share the same environment variables with the user's shell, depending on how they are set.

Loading the GitHub token from the git config is also nice unless the user's git config is synchronized as a "dotfile" to a public repository.

Instead, I thought it might be nice to support loading credentials from arbitrary files, a la `Credentials(Path.userHome / ".sbt" / ".credentials")` in the [sbt docs on credentials](https://www.scala-sbt.org/1.x/docs/Publishing.html#Credentials).

@djspiewak 